### PR TITLE
Add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,14 @@ jobs:
   # Run tests
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}
+    # runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: ubuntu-latest
         python: ["3.9", "3.13"]
         include:
           - python: "3.9"
@@ -179,7 +179,9 @@ jobs:
           ls -a
 
       - name: Make an HTML report
-        run: ls -a; python -m coverage html
+        run: |
+          ls -a
+          python -m coverage html
 
       - name: Report coverage on the job summary
         run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,180 @@
+# Configuration for running tests with GitHub Actions
+#
+name: test
+
+# Only build PRs, the main branch, and releases. Pushes to branches will only
+# be built when a PR is opened. This avoids duplicated buids in PRs comming
+# from branches in the origin repository (1 for PR and 1 for push).
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+permissions: {}
+
+# Use bash by default in all jobs
+defaults:
+  run:
+    # The -l {0} is necessary for conda environments to be activated
+    # But this breaks on MacOS if using actions/setup-python:
+    # https://github.com/actions/setup-python/issues/132
+    # -e makes sure builds fail if any command fails
+    shell: bash -e -o pipefail -l {0}
+
+jobs:
+  #############################################################################
+  # Run tests
+  test:
+    name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Otherwise, the workflow would stop if a single job fails. We want to
+      # run all of them to catch failures in different combinations.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.9", "3.13"]
+        include:
+          - python: "3.9"
+            dependencies: oldest
+          - python: "3.13"
+            dependencies: latest
+
+    env:
+      REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
+      # Used to tag codecov submissions
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python }}
+
+    steps:
+
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need to fetch more than the last commit so that setuptools_scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Need the tags so that setuptools_scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Collect requirements
+        run: |
+          echo "Install Dependente to capture dependencies:"
+          python -m pip install dependente==0.3.0
+          echo ""
+          echo "Capturing run-time dependencies:"
+          if [[ "${{ matrix.dependencies }}" == "oldest" ]]; then
+            dependente --source install --oldest > requirements-full.txt
+          else
+            dependente --source install > requirements-full.txt
+          fi
+          echo ""
+          echo "Capturing dependencies from:"
+          for requirement in $REQUIREMENTS
+          do
+            echo "  $requirement"
+            cat $requirement >> requirements-full.txt
+          done
+          echo ""
+          echo "Collected dependencies:"
+          cat requirements-full.txt
+
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-full.txt') }}
+
+      - name: Install requirements
+        run: |
+          python -m pip install --requirement requirements-full.txt
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Build source and wheel distributions
+        run: |
+          make build
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Install the package
+        run: python -m pip install --no-deps dist/*.whl
+
+      - name: Run the tests
+        run: make test
+
+      - name: Upload coverage as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: .coverage.*
+          name: coverage_${{ matrix.os }}_${{ matrix.python }}_${{ matrix.dependencies }}
+          if-no-files-found: ignore
+          include-hidden-files: true
+
+
+  #############################################################################
+  # Check coverage and upload a report
+  #
+  # Inspired by: https://hynek.me/articles/ditch-codecov-python/
+  coverage:
+    name: Combine & check coverage
+    if: always()
+    needs: tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # Use latest Python, so it understands all syntax.
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage_*
+          merge-multiple: true
+
+      - name: Combine coverage & fail if it's <100%
+        run: |
+          python -m pip install --upgrade coverage[toml]
+
+          python -m coverage combine
+          python -m coverage html --skip-covered --skip-empty
+
+          # Report and write to summary.
+          python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+
+          # Report again and fail if under 100%.
+          python -m coverage report --fail-under=100
+
+      - name: Upload HTML report if check failed
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report
+          path: htmlcov
+        if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
   coverage:
     name: Combine & check coverage
     if: always()
-    needs: tests
+    needs: test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ubuntu-latest
         python: ["3.9", "3.13"]
         include:
           - python: "3.9"
@@ -175,9 +176,10 @@ jobs:
       - name: Combine coverage
         run: |
           python -m coverage combine
+          ls -a
 
       - name: Make an HTML report
-        run: python -m coverage html
+        run: ls -a; python -m coverage html
 
       - name: Report coverage on the job summary
         run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
   #
   # Inspired by: https://hynek.me/articles/ditch-codecov-python/
   coverage:
-    name: Combine & check coverage
+    name: check test coverage == 100%
     if: always()
     needs: test
     runs-on: ubuntu-latest
@@ -175,8 +175,9 @@ jobs:
       - name: Combine coverage
         run: |
           python -m coverage combine
-          # Make an HTML report for uploading in case of failure
-          python -m coverage html --skip-covered --skip-empty
+
+      - name: Make an HTML report
+        run: python -m coverage html
 
       - name: Report coverage on the job summary
         run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
         run: python -m coverage combine
 
       - name: Make an HTML report
-        run: python -m coverage html
+        run: python -m coverage html --skip-empty
 
       - name: Report coverage on the job summary
         run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,14 +174,10 @@ jobs:
         run: python -m pip install --upgrade coverage[toml]
 
       - name: Combine coverage
-        run: |
-          python -m coverage combine
-          ls -a
+        run: python -m coverage combine
 
       - name: Make an HTML report
-        run: |
-          ls -a
-          python -m coverage html
+        run: python -m coverage html
 
       - name: Report coverage on the job summary
         run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,13 @@ jobs:
   # Run tests
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    # runs-on: ${{ matrix.os }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.9", "3.13"]
         include:
           - python: "3.9"
@@ -99,8 +98,7 @@ jobs:
 
       - name: Get the pip cache folder
         id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Setup caching for pip packages
         uses: actions/cache@v4
@@ -139,7 +137,7 @@ jobs:
   #
   # Inspired by: https://hynek.me/articles/ditch-codecov-python/
   coverage:
-    name: check test coverage == 100%
+    name: test coverage is 100%
     if: always()
     needs: test
     runs-on: ubuntu-latest
@@ -155,6 +153,16 @@ jobs:
         with:
           # Use latest Python, so it understands all syntax.
           python-version: "3.13"
+
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-coverage
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,15 +115,8 @@ jobs:
       - name: List installed packages
         run: python -m pip freeze
 
-      - name: Build source and wheel distributions
-        run: |
-          make build
-          echo ""
-          echo "Generated files:"
-          ls -lh dist/
-
       - name: Install the package
-        run: python -m pip install --no-deps dist/*.whl
+        run: python -m pip install --editable --no-deps src
 
       - name: Run the tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,8 +115,8 @@ jobs:
       - name: List installed packages
         run: python -m pip freeze
 
-      - name: Install the package
-        run: python -m pip install --editable --no-deps src
+      - name: Install the package in editable mode
+        run: python -m pip install --no-deps --editable .
 
       - name: Run the tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,10 @@ jobs:
       - name: Run the tests
         run: make test
 
+      - name: Rename the coverage artifact
+        run: |
+          mv .coverage .coverage.${{ matrix.os }}_${{ matrix.python }}_${{ matrix.dependencies }}
+
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -161,20 +165,24 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: coverage_*
+          # If true, the downloaded artifacts will be in the same directory
+          # specified by path.
           merge-multiple: true
 
-      - name: Combine coverage & fail if it's <100%
-        run: |
-          python -m pip install --upgrade coverage[toml]
+      - name: Install coverage.py
+        run: python -m pip install --upgrade coverage[toml]
 
+      - name: Combine coverage
+        run: |
           python -m coverage combine
+          # Make an HTML report for uploading in case of failure
           python -m coverage html --skip-covered --skip-empty
 
-          # Report and write to summary.
-          python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+      - name: Report coverage on the job summary
+        run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
 
-          # Report again and fail if under 100%.
-          python -m coverage report --fail-under=100
+      - name: Fail if coverage is not 100%
+        run: python -m coverage report --fail-under=100
 
       - name: Upload HTML report if check failed
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 	python -m pip install --no-deps --editable .
 
 test:
-	pytest --cov-report=term-missing --cov=$(PROJECT) --doctest-modules --verbose test $(PROJECT)
+	pytest --cov-report=term-missing --cov=$(PROJECT) --doctest-modules --verbose test src/$(PROJECT)
 
 format:
 	ruff check --select I --fix $(CHECK_STYLE) # fix isort errors

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ build:
 	python -m build .
 
 install:
-	python -m pip install --no-deps -e .
+	python -m pip install --no-deps --editable .
 
 test:
-	pytest test
+	pytest --cov-report=term-missing --cov=$(PROJECT) --doctest-modules --verbose test $(PROJECT)
 
 format:
 	ruff check --select I --fix $(CHECK_STYLE) # fix isort errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ omit = [
     "**/_version.py",
     "**/__init__.py",
 ]
+# Needed to combine coverage data from multiple OSs on CI
+relative_files = true
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,3 @@ omit = [
 
 [tool.coverage.report]
 show_missing = true
-
-[tool.pytest.ini_options]
-addopts = "--cov-report=term-missing --cov=bordado --doctest-modules --verbose"

--- a/src/bordado/_dummy.py
+++ b/src/bordado/_dummy.py
@@ -5,12 +5,11 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 """
-A placeholder file until we have tests.
+Dummy module so tests don't fail.
 """
 
-from bordado._dummy import dummy
 
+def dummy():
+    """Calculate nothing."""
+    return "bla"
 
-def test_nothing():
-    """Docstring."""
-    assert dummy() == "bla"

--- a/src/bordado/_dummy.py
+++ b/src/bordado/_dummy.py
@@ -12,4 +12,3 @@ Dummy module so tests don't fail.
 def dummy():
     """Calculate nothing."""
     return "bla"
-

--- a/test/test_placeholder.py
+++ b/test/test_placeholder.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+A placeholder file until we have tests.
+"""
+import bordado
+
+
+def test_nothing():
+    assert bordado.__name__ == "bordado"

--- a/test/test_placeholder.py
+++ b/test/test_placeholder.py
@@ -12,4 +12,5 @@ import bordado
 
 
 def test_nothing():
+    """Docstring."""
     assert bordado.__name__ == "bordado"

--- a/test/test_placeholder.py
+++ b/test/test_placeholder.py
@@ -7,6 +7,7 @@
 """
 A placeholder file until we have tests.
 """
+
 import bordado
 
 


### PR DESCRIPTION
Runs the tests and checks the coverage using a custom step instead of Codecov. Based on https://hynek.me/articles/ditch-codecov-python/. Add a dummy test so that `make test` doesn't fail because no tests were found. Install the package in editable mode instead of building a wheel because coverage can't find the source files otherwise. Coverage must be run with relative paths in order to combine the results from different OSs on CI.


