### PR TITLE
Add GitHub Actions to check style and format

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,52 @@
+# Linting and style checks with GitHub Actions
+#
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
+name: code-style
+
+# Only build PRs and the main branch. Pushes to branches will only be built
+# when a PR is opened.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+###############################################################################
+jobs:
+  check:
+    name: check style and format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('env/requirements-style.txt') }}
+
+      - name: Install requirements
+        run: python -m pip install -r env/requirements-style.txt
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Check code style and format
+        run: make check


### PR DESCRIPTION
Check style and format in a single job to avoid wasting resources. Add a placeholder `doc` folder to avoid failures.
