### PR TITLE
Remove pandas as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.23",
     "scipy>=1.8",
-    "pandas>=1.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
We won't actually use it. And if we do need it at some point, we can add it back.