### PR TITLE
Add GitHub Actions workflow for PyPI publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,113 @@
+# Publish archives to PyPI and TestPyPI using GitHub Actions.
+#
+name: pypi
+
+# Only run for pushes to the main branch and releases.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+permissions: {}
+
+# Use bash by default in all jobs
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need to fetch more than the last commit so that setuptools_scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version will still be
+          # wrong. Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Need the tags so that setuptools-scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install requirements
+        run: python -m pip install -r env/requirements-build.txt
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Build source and wheel distributions
+        run: |
+          make build
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Check the archives
+        run: twine check dist/*
+
+      # Store the archives as a build artifact so we can deploy them later
+      - name: Upload archives as artifacts
+        # Only if not a pull request
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-${{ github.sha }}
+          path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    # Only publish from the origin repository, not forks
+    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    environment: pypi
+    permissions:
+      # This permission allows trusted publishing to PyPI (without an API token)
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Fetch the built archives from the "build" job
+      - name: Download built archives artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-${{ github.sha }}
+          path: dist
+
+      - name: Publish to Test PyPI
+        # Only publish to TestPyPI when a PR is merged (pushed to main)
+        if: success() && github.event_name == 'push'
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          # Allow existing releases on test PyPI without errors.
+          # NOT TO BE USED in PyPI!
+          skip_existing: true
+
+      - name: Publish to PyPI
+        # Only publish to PyPI when a release triggers the build
+        if: success() && github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
Builds and checks packages, uploads to TestPyPI from "main" and to actual PyPI on releases.