### PR TITLE
Add pad_region function to expand a region

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -12,3 +12,4 @@ List of functions and classes (API)
 
    line_coordinates
    check_region
+   pad_region

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -9,7 +9,7 @@ These are the functions and classes that make up the Bordado API.
 """
 
 from ._line import line_coordinates
-from ._region import check_region
+from ._region import check_region, pad_region
 from ._version import __version__
 
 # Append a leading "v" to the generated version by setuptools_scm

--- a/src/bordado/_region.py
+++ b/src/bordado/_region.py
@@ -52,3 +52,52 @@ def check_region(region):
             f"in dimension(s): {'; '.join(bad_bounds)}"
         )
         raise ValueError(message)
+
+
+def pad_region(region, pad):
+    """
+    Extend the borders of a region by the given amount.
+
+    Parameters
+    ----------
+    region : list = [W, E, S, N, ...]
+        The boundaries of a given region in Cartesian or geographic
+        coordinates. Should have a lower and an upper boundary for each
+        dimension of the coordinate system.
+    pad : float or tuple = (pad_WE, pad_SN, ...)
+        The amount of padding to add to the region. If it's a single number,
+        add this to all boundaries of region equally. If it's a tuple of
+        numbers, then will add different padding to each dimension of the
+        region respectively. If a tuple, the number of elements should be half
+        of the number of elements in *region*.
+
+    Returns
+    -------
+    padded_region : tuple = (W, E, S, N, ...)
+        The padded region.
+
+    Examples
+    --------
+    >>> pad_region((0, 1, -5, -3), 1)
+    (-1, 2, -6, -2)
+    >>> pad_region((0, 1, -5, -3, 6, 7), 1)
+    (-1, 2, -6, -2, 5, 8)
+    >>> pad_region((0, 1, -5, -3), (2, 3))
+    (-2, 3, -8, 0)
+    >>> pad_region((0, 1, -5, -3, 6, 7), (2, 3, 1))
+    (-2, 3, -8, 0, 5, 8)
+
+    """
+    check_region(region)
+    ndims = len(region) // 2
+    if np.isscalar(pad):
+        pad = tuple(pad for _ in range(ndims))
+    if len(pad) != ndims:
+        message = (
+            f"Invalid padding '{pad}'. "
+            f"Should have {ndims} elements for region '{region}'."
+        )
+        raise ValueError(message)
+    region_pairs = np.reshape(region, (len(region) // 2, 2))
+    padded = [[lower - p, upper + p] for p, (lower, upper) in zip(pad, region_pairs)]
+    return tuple(np.ravel(padded).tolist())

--- a/test/test_region.py
+++ b/test/test_region.py
@@ -10,7 +10,7 @@ Test the input and output validation functions.
 
 import pytest
 
-from bordado._region import check_region
+from bordado._region import check_region, pad_region
 
 
 @pytest.mark.parametrize(
@@ -25,7 +25,7 @@ from bordado._region import check_region
     ],
 )
 def test_check_region_raises(region, message):
-    """Make sure an exception is raised for bad regions."""
+    "Make sure an exception is raised for bad regions."
     with pytest.raises(ValueError, match=message):
         check_region(region)
 
@@ -40,5 +40,25 @@ def test_check_region_raises(region, message):
     ],
 )
 def test_check_region_passes(region):
-    """Check that valid regions don't cause exceptions."""
+    "Check that valid regions don't cause exceptions."
     check_region(region)
+
+
+@pytest.mark.parametrize(
+    ("region", "pad"),
+    [
+        ([1, 2, 3, 4], (1,)),
+        ([1, 2, 3, 4], (1, 2, 3)),
+        ([-2, -1, -5, -4, 0, 1], (1,)),
+        ([-2, -1, -5, -4, 0, 1], (1, 2)),
+        ([-2, -1, -5, -4, 0, 1], (1, 2, 3, 4)),
+        ([-2, -1, -5, -4, 0, 1, 10, 20], (1,)),
+        ([-2, -1, -5, -4, 0, 1, 10, 20], (1, 2)),
+        ([-2, -1, -5, -4, 0, 1, 10, 20], (1, 2, 3)),
+        ([-2, -1, -5, -4, 0, 1, 10, 20], (1, 2, 3, 4, 5)),
+    ],
+)
+def test_pad_region_fails(region, pad):
+    "Check if an exception is raised for invalid padding."
+    with pytest.raises(ValueError, match="Invalid padding"):
+        pad_region(region, pad)


### PR DESCRIPTION
Port the function from Verde but expand it to n-dimensional regions. The order of the pad argument was changed from what Verde implemented. Here, it follows the same order as the dimensions of the grid, as would be expected.

