### PR TITLE
Add a function to get the region from coordinates

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -7,9 +7,20 @@ List of functions and classes (API)
 
 .. currentmodule:: bordado
 
+Coordinate generation
+---------------------
+
 .. autosummary::
    :toctree: generated/
 
    line_coordinates
-   check_region
+
+Regions and bounding boxes
+--------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   get_region
    pad_region
+   check_region

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -9,7 +9,7 @@ These are the functions and classes that make up the Bordado API.
 """
 
 from ._line import line_coordinates
-from ._region import check_region, pad_region
+from ._region import check_region, get_region, pad_region
 from ._version import __version__
 
 # Append a leading "v" to the generated version by setuptools_scm

--- a/src/bordado/_region.py
+++ b/src/bordado/_region.py
@@ -101,3 +101,31 @@ def pad_region(region, pad):
     region_pairs = np.reshape(region, (len(region) // 2, 2))
     padded = [[lower - p, upper + p] for p, (lower, upper) in zip(pad, region_pairs)]
     return tuple(np.ravel(padded).tolist())
+
+
+def get_region(coordinates):
+    """
+    Get the bounding region of the given coordinates.
+
+    Parameters
+    ----------
+    coordinates : tuple of arrays
+        Arrays with the coordinates of each data point. Should be in the
+        following order: (easting, northing, vertical, ...).
+
+    Returns
+    -------
+    region : tuple = (W, E, S, N, ...)
+        The boundaries of a given region in Cartesian or geographic
+        coordinates.
+
+    Examples
+    --------
+    >>> get_region(([0, 0.5, 1], [-10, -8, -6]))
+    (0.0, 1.0, -10.0, -6.0)
+    >>> get_region(([0, 0.5, 1], [-10, -8, -6], [4, 10, 16]))
+    (0.0, 1.0, -10.0, -6.0, 4.0, 16.0)
+
+    """
+    region = tuple(np.ravel([[np.min(c), np.max(c)] for c in coordinates]).tolist())
+    return region


### PR DESCRIPTION
Adapt the Verde function `get_region` to work with n-dimensional coordinates. Start sorting the API reference into sections.

