### PR TITLE
Make arguments of line_coordinates keyword-only

### DIFF
--- a/src/bordado/_line.py
+++ b/src/bordado/_line.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 def line_coordinates(
-    start, stop, size=None, spacing=None, adjust="spacing", pixel_register=False
+    start, stop, *, size=None, spacing=None, adjust="spacing", pixel_register=False
 ):
     """
     Generate evenly spaced points between two values.


### PR DESCRIPTION
The keyword-only syntax helps prevent errors like passing spacing as the second positional argument.


**Relevant issues/PRs:** Fixes #19 