### PR TITLE
Add function to make a random scatter of points

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -14,6 +14,7 @@ Coordinate generation
    :toctree: generated/
 
    line_coordinates
+   scatter_points
 
 Regions and bounding boxes
 --------------------------

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -9,6 +9,7 @@ These are the functions and classes that make up the Bordado API.
 """
 
 from ._line import line_coordinates
+from ._random import scatter_points
 from ._region import check_region, get_region, inside, pad_region
 from ._version import __version__
 

--- a/src/bordado/_random.py
+++ b/src/bordado/_random.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Functions for generating random point spreads.
+"""
+
+import numpy as np
+
+from ._region import check_region
+
+
+def get_rng(random_state):
+    """
+    Produce a random number generator based on the random state given.
+
+    Parameters
+    ----------
+    random_state : numpy.random.Generator or int
+        A random number generator used to generate the coordinates. If an
+        integer, will be used as a seed for :func:`numpy.random.default_rng`.
+        Use a seed to make sure computations are reproducible. If
+        a :class:`numpy.random.Generator` is given, it will be used. Use
+        ``None`` to use :func:`~numpy.random.default_rng` with no seed
+        (resulting in different numbers with each run).
+
+    Returns
+    -------
+    random : numpy.random.Generator
+        The random number generator.
+    """
+    if random_state is None:
+        random = np.random.default_rng()
+    elif isinstance(random_state, int):
+        random = np.random.default_rng(random_state)
+    else:
+        random = random_state
+    return random
+
+
+def scatter_points(region, size, *, random_state=None, non_dimensional_coords=None):
+    """
+    Generate the coordinates for a random scatter of points.
+
+    The points are drawn from a uniform distribution.
+
+    Parameters
+    ----------
+    region : tuple = (W, E, S, N, ...)
+        The boundaries of a given region in Cartesian or geographic
+        coordinates. Should have a lower and an upper boundary for each
+        dimension of the coordinate system.
+    size : int
+        The number of points to generate.
+    random_state : numpy.random.Generator or int
+        A random number generator used to generate the coordinates. If an
+        integer, will be used as a seed for :func:`numpy.random.default_rng`.
+        Use a seed to make sure computations are reproducible. If
+        a :class:`numpy.random.Generator` is given, it will be used. Use
+        ``None`` to use :func:`~numpy.random.default_rng` with no seed
+        (resulting in different numbers with each run). Default is None.
+    non_dimensional_coords : None, scalar, or tuple of scalars
+        If not None, then value(s) of extra non-dimensional coordinates
+        (coordinates that aren't part of the sample dimensions, like height for
+        a lat/lon grid). Will generate extra coordinate arrays from these
+        values with the same shape of the final coordinates and the constant
+        value given here. Use this to generate arrays of constant heights or
+        times, for example, which might be needed to accompany a set of points.
+
+    Returns
+    -------
+    coordinates : tuple of arrays
+        Arrays with coordinates of each point in the grid. Each array contains
+        values for a dimension in an order compatible with *region* followed by
+        any extra dimensions given in *non_dimensional_coords*. All arrays will
+        have the specified *size*.
+
+    Examples
+    --------
+    We'll use a seed value to ensure that the same will be generated every
+    time:
+
+    >>> easting, northing = scatter_points((0, 10, -2, -1), 4, random_state=0)
+    >>> print(', '.join(['{:.4f}'.format(i) for i in easting]))
+    6.3696, 2.6979, 0.4097, 0.1653
+    >>> print(', '.join(['{:.4f}'.format(i) for i in northing]))
+    -1.1867, -1.0872, -1.3934, -1.2705
+    >>> easting, northing, height = scatter_points(
+    ...     (0, 10, -2, -1), 4, random_state=0, non_dimensional_coords=12
+    ... )
+    >>> print(height)
+    [12. 12. 12. 12.]
+    >>> easting, northing, height, time = scatter_points(
+    ...     (0, 10, -2, -1), 4, random_state=0, non_dimensional_coords=[12, 1986])
+    >>> print(height)
+    [12. 12. 12. 12.]
+    >>> print(time)
+    [1986. 1986. 1986. 1986.]
+
+    We're not limited to 2 dimensions:
+
+    >>> easting, northing, up = scatter_points(
+    ...     (0, 10, -2, -1, 0.1, 0.2), 4, random_state=0,
+    ... )
+    >>> print(', '.join(['{:.4f}'.format(i) for i in easting]))
+    6.3696, 2.6979, 0.4097, 0.1653
+    >>> print(', '.join(['{:.4f}'.format(i) for i in northing]))
+    -1.1867, -1.0872, -1.3934, -1.2705
+    >>> print(', '.join(['{:.4f}'.format(i) for i in up]))
+    0.1544, 0.1935, 0.1816, 0.1003
+
+    """
+    check_region(region)
+    random = get_rng(random_state)
+    coordinates = []
+    for lower, upper in np.reshape(region, (len(region) // 2, 2)):
+        coordinates.append(random.uniform(lower, upper, size))
+    if non_dimensional_coords is not None:
+        for value in np.atleast_1d(non_dimensional_coords):
+            coordinates.append(np.full_like(coordinates[0], value))
+    return tuple(coordinates)

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Test the random coordinate generation functions.
+"""
+
+import numpy as np
+import numpy.testing as npt
+
+from bordado._random import get_rng
+
+
+def test_get_rng_none():
+    "Check that the random number generator is not seeded"
+    result1 = get_rng(None).uniform(0, 1, 10)
+    result2 = get_rng(None).uniform(0, 1, 10)
+    assert not np.allclose(result1, result2)
+
+
+def test_get_rng_int():
+    "Check that the random number generator is seeded"
+    result1 = get_rng(1).uniform(0, 1, 10)
+    result2 = get_rng(1).uniform(0, 1, 10)
+    npt.assert_allclose(result1, result2)
+
+
+def test_get_rng_custom_rng():
+    "Check that passing a Generator works"
+    # Using the same RNG should not lead to identical sequences
+    random = np.random.default_rng(10)
+    result1 = get_rng(random).uniform(0, 1, 10)
+    result2 = get_rng(random).uniform(0, 1, 10)
+    assert not np.allclose(result1, result2)
+    # But seeding the RNG equally twice should
+    result1 = get_rng(np.random.default_rng(10)).uniform(0, 1, 10)
+    result2 = get_rng(np.random.default_rng(10)).uniform(0, 1, 10)
+    npt.assert_allclose(result1, result2)


### PR DESCRIPTION
Port over the `scatter_points` function from Verde. This one was already supporting n-dimensional regions. Had to adapt the random state function from scikit-learn. Results are different because our function now uses the new numpy.random.Generator objects.