### PR TITLE
Add function to check coordinates have same shape

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -27,3 +27,11 @@ Regions and bounding boxes
    get_region
    pad_region
    check_region
+
+Coordinate manipulation
+-----------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   check_coordinates

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -8,6 +8,7 @@
 These are the functions and classes that make up the Bordado API.
 """
 
+from ._coordinates import check_coordinates
 from ._grid import grid_coordinates
 from ._line import line_coordinates
 from ._random import random_coordinates

--- a/src/bordado/_coordinates.py
+++ b/src/bordado/_coordinates.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Functions for validating and manipulation coordinate arrays.
+"""
+
+import numpy as np
+
+
+def check_coordinates(coordinates):
+    """
+    Check that coordinate arrays all have the same shape.
+
+    Parameters
+    ----------
+    coordinates : tuple = (easting, northing, ...)
+        Tuple of arrays with the coordinates of each point. Arrays can be
+        Python lists.
+
+    Returns
+    -------
+    coordinates : tuple = (easting, northing, ...)
+        Tuple of coordinate arrays, converted to numpy arrays if necessary.
+
+    Raises
+    ------
+    ValueError
+        If the coordinates don't have the same shape.
+    """
+    coordinates = tuple(np.asarray(c) for c in coordinates)
+    shapes = [c.shape for c in coordinates]
+    if not all(shape == shapes[0] for shape in shapes):
+        message = (
+            "Invalid coordinates. All coordinate arrays must have the same shape. "
+            f"Given coordinate shapes: {shapes}"
+        )
+        raise ValueError(message)
+    return coordinates

--- a/src/bordado/_region.py
+++ b/src/bordado/_region.py
@@ -10,6 +10,8 @@ Functions for dealing with regions and bounding boxes.
 
 import numpy as np
 
+from ._coordinates import check_coordinates
+
 
 def check_region(region):
     """
@@ -109,9 +111,10 @@ def get_region(coordinates):
 
     Parameters
     ----------
-    coordinates : tuple of arrays
-        Arrays with the coordinates of each data point. Should be in the
-        following order: (easting, northing, vertical, ...).
+    coordinates : tuple = (easting, northing, ...)
+        Tuple of arrays with the coordinates of each point. Arrays can be
+        Python lists. Arrays can be of any shape but must all have the same
+        shape.
 
     Returns
     -------
@@ -127,6 +130,7 @@ def get_region(coordinates):
     (0.0, 1.0, -10.0, -6.0, 4.0, 16.0)
 
     """
+    coordinates = check_coordinates(coordinates)
     region = tuple(np.ravel([[np.min(c), np.max(c)] for c in coordinates]).tolist())
     return region
 
@@ -139,9 +143,11 @@ def inside(coordinates, region):
 
     Parameters
     ----------
-    coordinates : tuple of arrays
-        Arrays with the coordinates of each data point. Should be in an order
-        compatible with the order of boundaries in *region*.
+    coordinates : tuple = (easting, northing, ...)
+        Tuple of arrays with the coordinates of each point. Should be in an
+        order compatible with the order of boundaries in *region*. Arrays can
+        be Python lists. Arrays can be of any shape but must all have the same
+        shape.
     region : tuple = (W, E, S, N, ...)
         The boundaries of a given region in Cartesian or geographic
         coordinates. Should have a lower and an upper boundary for each
@@ -204,6 +210,7 @@ def inside(coordinates, region):
 
     """
     check_region(region)
+    coordinates = check_coordinates(coordinates)
     ndims = len(region) // 2
     if len(coordinates) != ndims:
         message = (
@@ -211,7 +218,6 @@ def inside(coordinates, region):
             f"but got {len(coordinates)} instead."
         )
         raise ValueError(message)
-    coordinates = [np.asarray(c) for c in coordinates]
     region_pairs = np.reshape(region, (ndims, 2))
     shape = coordinates[0].shape
     # Allocate temporary arrays to minimize memory allocation overhead

--- a/test/test_coordinates.py
+++ b/test/test_coordinates.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Test the coordinate validation and manipulation functions.
+"""
+
+import pytest
+
+from bordado._coordinates import check_coordinates
+
+
+@pytest.mark.parametrize(
+    ("coordinates"),
+    [
+        ([1, 2], [[1, 2]]),
+        ([1, 2], [[1], [2]]),
+        ([[1], [2]], [1, 2]),
+        ([[1, 2]], [1, 2]),
+    ],
+)
+def test_check_coordinates_fails(coordinates):
+    "Make sure the exception is raised for bad coordinates."
+    with pytest.raises(ValueError, match="Invalid coordinates"):
+        check_coordinates(coordinates)
+
+
+@pytest.mark.parametrize(
+    ("coordinates"),
+    [
+        ([[1, 2]], [[1, 2]]),
+        ([[1], [2]], [[1], [2]]),
+        ([[1], [2]], [[3], [4]]),
+        ([[1, 2]], [[3, 4]]),
+    ],
+)
+def test_check_coordinates_passes(coordinates):
+    "Make sure no exception is raised for good coordinates."
+    check_coordinates(coordinates)


### PR DESCRIPTION
The `check_coordinates` function was ported from Verde and made part of the public API of Bordado. It also makes sure the coordinates are numpy arrays so that we can use lists when passing coordinates to other functions. Use the function in other functions and improve their docstrings description of coordinates.


