### PR TITLE
Add a function to split points into blocks

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -28,6 +28,14 @@ Regions and bounding boxes
    pad_region
    check_region
 
+Splitting points into blocks and windows
+----------------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   block_split
+
 Coordinate manipulation
 -----------------------
 

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -13,8 +13,8 @@ from ._grid import grid_coordinates
 from ._line import line_coordinates
 from ._random import random_coordinates
 from ._region import check_region, get_region, inside, pad_region
-from ._version import __version__
 from ._split import block_split
+from ._version import __version__
 
 # Append a leading "v" to the generated version by setuptools_scm
 __version__ = f"v{__version__}"

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -14,6 +14,7 @@ from ._line import line_coordinates
 from ._random import random_coordinates
 from ._region import check_region, get_region, inside, pad_region
 from ._version import __version__
+from ._split import block_split
 
 # Append a leading "v" to the generated version by setuptools_scm
 __version__ = f"v{__version__}"

--- a/src/bordado/_line.py
+++ b/src/bordado/_line.py
@@ -141,12 +141,7 @@ def _spacing_to_size(start, stop, spacing, adjust):
         The end of the interval, which may or may not have been adjusted.
 
     """
-    if adjust not in ["spacing", "region"]:
-        message = (
-            f"Invalid value for 'adjust' argument '{adjust}'. "
-            "Should be 'spacing' or 'region'"
-        )
-        raise ValueError(message)
+    check_adjust(adjust)
     # Add 1 to get the number of nodes, not segments
     size = int(round((stop - start) / spacing) + 1)
     # If the spacing >= 2 * (stop - start), it rounds to zero so we'd be
@@ -166,3 +161,26 @@ def _spacing_to_size(start, stop, spacing, adjust):
         stop = stop + pad
         start = start - pad
     return size, start, stop
+
+
+def check_adjust(adjust, valid=("spacing", "region")):
+    """
+    Check if the adjust argument is valid.
+
+    Parameters
+    ----------
+    adjust : str
+        The value of the adjust argument given to a function.
+    valid : list or tuple
+        The list of valid values for the argument.
+
+    Raises
+    ------
+    ValueError
+        In case the argument is not in the list of valid values.
+    """
+    if adjust not in valid:
+        message = (
+            f"Invalid value for 'adjust' argument '{adjust}'. Should be one of {valid}."
+        )
+        raise ValueError(message)

--- a/src/bordado/_split.py
+++ b/src/bordado/_split.py
@@ -1,0 +1,95 @@
+"""
+Functions to split points into blocks and windows.
+"""
+import numpy as np
+from scipy.spatial import KDTree
+
+
+def block_split(coordinates, *, block_shape=None, block_size=None, adjust="spacing", region=None):
+    """
+    Split a region into blocks and label points according to where they fall.
+
+    The labels are integers corresponding to the index of the block. Also
+    returns the coordinates of the center of each block (following the same
+    index as the labels).
+
+    Blocks can be specified by their size or the number of blocks in each
+    dimension (the shape).
+
+    Parameters
+    ----------
+    coordinates : tuple = (easting, northing, ...)
+        Tuple of arrays with the coordinates of each point. The arrays can be
+        n-dimensional.
+    shape : tuple = (..., n_north, n_east) or None
+        The number of blocks in the South-North and West-East directions,
+        respectively.
+    spacing : float, tuple = (..., space_north, space_east), or None
+        The block size in the South-North and West-East directions,
+        respectively. A single value means that the size is equal in both
+        directions.
+    adjust : {'spacing', 'region'}
+        Whether to adjust the spacing or the region if required. Ignored if
+        *shape* is given instead of *spacing*. Defaults to adjusting the
+        spacing.
+    region : list = [W, E, S, N]
+        The boundaries of a given region in Cartesian or geographic
+        coordinates. If not region is given, will use the bounding region of
+        the given points.
+
+    Returns
+    -------
+    block_coordinates : tuple of arrays
+        (easting, northing) arrays with the coordinates of the center of each
+        block.
+    labels : array
+        integer label for each data point. The label is the index of the block
+        to which that point belongs.
+
+    Examples
+    --------
+    >>> from verde import grid_coordinates
+    >>> coords = grid_coordinates((-5, 0, 5, 10), spacing=1)
+    >>> block_coords, labels = block_split(coords, spacing=2.5)
+    >>> for coord in block_coords:
+    ...     print(', '.join(['{:.2f}'.format(i) for i in coord]))
+    -3.75, -1.25, -3.75, -1.25
+    6.25, 6.25, 8.75, 8.75
+    >>> print(labels.reshape(coords[0].shape))
+    [[0 0 0 1 1 1]
+     [0 0 0 1 1 1]
+     [0 0 0 1 1 1]
+     [2 2 2 3 3 3]
+     [2 2 2 3 3 3]
+     [2 2 2 3 3 3]]
+    >>> # Use the shape instead of the block size
+    >>> block_coords, labels = block_split(coords, shape=(4, 2))
+    >>> for coord in block_coords:
+    ...     print(', '.join(['{:.3f}'.format(i) for i in coord]))
+    -3.750, -1.250, -3.750, -1.250, -3.750, -1.250, -3.750, -1.250
+    5.625, 5.625, 6.875, 6.875, 8.125, 8.125, 9.375, 9.375
+    >>> print(labels.reshape(coords[0].shape))
+    [[0 0 0 1 1 1]
+     [0 0 0 1 1 1]
+     [2 2 2 3 3 3]
+     [4 4 4 5 5 5]
+     [6 6 6 7 7 7]
+     [6 6 6 7 7 7]]
+
+    """
+    # Select the coordinates after checking to make sure indexing will still
+    # work on the ignored coordinates.
+    coordinates = check_coordinates(coordinates)[:2]
+    if region is None:
+        region = get_region(coordinates)
+    block_coords = grid_coordinates(
+        region, spacing=spacing, shape=shape, adjust=adjust, pixel_register=True
+    )
+
+    points = np.transpose(n_1d_arrays(coordinates, len(coordinates)))
+    tree = cKDTree(points, **kwargs)
+
+    tree = kdtree(block_coords)
+
+    labels = tree.query(np.transpose(n_1d_arrays(coordinates, 2)))[1]
+    return n_1d_arrays(block_coords, len(block_coords)), labels


### PR DESCRIPTION
Add the `block_split` function from Verde. Modify the function to accept N-dimensions instead of just 2, use the checking functions from Bordado, and rename arguments `shape -> block_shape` and `spacing -> block_size` since they make much more sense in this context. Expanded the tests to n-dimensional and using custom regions.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:** Related to #27 
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
