### PR TITLE
Make sure get_region works with pandas and xarray

### DIFF
--- a/env/requirements-test.txt
+++ b/env/requirements-test.txt
@@ -2,3 +2,5 @@
 pytest
 pytest-cov
 coverage
+pandas
+xarray

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,8 @@ dependencies:
   - pytest
   - pytest-cov
   - coverage
+  - pandas
+  - xarray
   # Documentation
   - sphinx==7.2.*
   - numpydoc==1.7.*

--- a/src/bordado/_region.py
+++ b/src/bordado/_region.py
@@ -113,8 +113,8 @@ def get_region(coordinates):
     ----------
     coordinates : tuple = (easting, northing, ...)
         Tuple of arrays with the coordinates of each point. Arrays can be
-        Python lists. Arrays can be of any shape but must all have the same
-        shape.
+        Python lists or any numpy-compatible array type. Arrays can be of any
+        shape but must all have the same shape.
 
     Returns
     -------

--- a/test/test_region.py
+++ b/test/test_region.py
@@ -8,9 +8,12 @@
 Test the input and output validation functions.
 """
 
+import numpy as np
+import pandas as pd
 import pytest
+import xarray as xr
 
-from bordado._region import check_region, inside, pad_region
+from bordado._region import check_region, get_region, inside, pad_region
 
 
 @pytest.mark.parametrize(
@@ -79,3 +82,17 @@ def test_inside_fails_len_coordinates(region, coordinates):
     match = f"Expected {len(region) // 2} .* got {len(coordinates)} .*"
     with pytest.raises(ValueError, match=match):
         inside(coordinates, region)
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        (np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0, 3.0])),
+        (pd.Series([1.0, 2.0, 3.0]), pd.Series([1.0, 2.0, 3.0])),
+        (xr.DataArray([1.0, 2.0, 3.0]), xr.DataArray([1.0, 2.0, 3.0])),
+    ],
+)
+def test_get_region_array_dtypes(coordinates):
+    "Make sure the region has floats and not arrays or numpy dtypes"
+    region = get_region(coordinates)
+    assert all(isinstance(i, float) for i in region)


### PR DESCRIPTION
Test passing `pandas.Series` and `xarray.DataArray` to make sure the region has floats or ints in the end instead of numpy numbers or xarray objects. The existing code already worked with those dtypes.

**Relevant issues/PRs:** Fixes #35 