### PR TITLE
Make spacing_to_size public in the API

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -38,10 +38,11 @@ Splitting points into blocks and windows
    expanding_window
    rolling_window
 
-Coordinate manipulation
------------------------
+Other utilities
+---------------
 
 .. autosummary::
    :toctree: generated/
 
    check_coordinates
+   spacing_to_size

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -10,7 +10,7 @@ These are the functions and classes that make up the Bordado API.
 
 from ._coordinates import check_coordinates
 from ._grid import grid_coordinates
-from ._line import line_coordinates
+from ._line import line_coordinates, spacing_to_size
 from ._random import random_coordinates
 from ._region import check_region, get_region, inside, pad_region
 from ._split import block_split, expanding_window, rolling_window

--- a/src/bordado/_line.py
+++ b/src/bordado/_line.py
@@ -100,7 +100,7 @@ def line_coordinates(
         message = "Either a size or a spacing must be provided."
         raise ValueError(message)
     if spacing is not None:
-        size, start, stop = _spacing_to_size(start, stop, spacing, adjust)
+        size, start, stop = spacing_to_size(start, stop, spacing, adjust=adjust)
     elif pixel_register and size is not None:
         # Starts by generating grid-line registered coordinates and shifting
         # them to the center of the pixel. Need 1 more point if given a size
@@ -113,11 +113,13 @@ def line_coordinates(
     return values
 
 
-def _spacing_to_size(start, stop, spacing, adjust):
+def spacing_to_size(start, stop, spacing, *, adjust="spacing"):
     """
     Convert a spacing to the number of points between start and stop.
 
-    Takes into account if the spacing or the interval needs to be adjusted.
+    Takes into account if the spacing or the interval needs to be adjusted in
+    order to fit exactly. This is needed when the interval is not a multiple of
+    the spacing.
 
     Parameters
     ----------
@@ -140,6 +142,28 @@ def _spacing_to_size(start, stop, spacing, adjust):
     stop : float
         The end of the interval, which may or may not have been adjusted.
 
+    Examples
+    --------
+    If the spacing is a multiple of the interval, then the size is how many
+    points fit in the interval and the start and stop values are maintained:
+
+    >>> size, start, stop = spacing_to_size(0, 1, 0.5)
+    >>> print(size, start, stop)
+    3 0 1
+
+    If the spacing is not a multiple, then it will be adjusted to fit the
+    interval by default. In this case, then number of points remains the same:
+
+    >>> size, start, stop = spacing_to_size(0, 1, 0.6)
+    >>> print(size, start, stop)
+    3 0 1
+
+    Alternatively, we can ask it to adjust the region instead of the spacing
+    between points:
+
+    >>> size, start, stop = spacing_to_size(0, 1, 0.6, adjust="region")
+    >>> print(f"{size} {start:.1f} {stop:.1f}")
+    3 -0.1 1.1
     """
     check_adjust(adjust)
     # Add 1 to get the number of nodes, not segments

--- a/test/test_line.py
+++ b/test/test_line.py
@@ -11,7 +11,7 @@ Test the coordinate generation functions.
 import numpy.testing as npt
 import pytest
 
-from bordado._line import _spacing_to_size, line_coordinates
+from bordado._line import line_coordinates, spacing_to_size
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,7 @@ from bordado._line import _spacing_to_size, line_coordinates
 def test_spacing_to_size(spacing, adjust, expected_start, expected_stop, expected_size):
     "Check that correct size and stop are returned"
     start, stop = -10, 0
-    size, new_start, new_stop = _spacing_to_size(
+    size, new_start, new_stop = spacing_to_size(
         start, stop, spacing=spacing, adjust=adjust
     )
     npt.assert_allclose(size, expected_size)
@@ -39,7 +39,7 @@ def test_spacing_to_size(spacing, adjust, expected_start, expected_stop, expecte
 def test_spacing_to_size_fails():
     "Check that invalid adjust causes an exception"
     with pytest.raises(ValueError, match="Invalid value for 'adjust'"):
-        _spacing_to_size(0, 1, spacing=0.1, adjust="invalid adjust value")
+        spacing_to_size(0, 1, spacing=0.1, adjust="invalid adjust value")
 
 
 def test_line_coordinates_fails():


### PR DESCRIPTION
Added some examples to the docstring to complement it. This is a useful function and may be used elsewhere. It's what makes the coordinate generation functions useful.

**Relevant issues/PRs:** Fixes #41 