### PR TITLE
Add function for statistics of nearest neighbor distances

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -43,6 +43,7 @@ Other utilities
 .. autosummary::
    :toctree: generated/
 
+   neighbor_distance_statistics
    spacing_to_size
    shape_to_spacing
 

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -8,6 +8,7 @@
 These are the functions and classes that make up the Bordado API.
 """
 
+from ._distance import neighbor_distance_statistics
 from ._grid import grid_coordinates
 from ._line import line_coordinates
 from ._random import random_coordinates

--- a/src/bordado/_distance.py
+++ b/src/bordado/_distance.py
@@ -14,13 +14,17 @@ import scipy.spatial
 from ._validation import check_coordinates
 
 
-def neighbor_distance_statistics(coordinates, *, k_nearest=1, statistic="mean"):
+def neighbor_distance_statistics(coordinates, statistic, *, k_nearest=1):
     """
-    Median distance between the *k* nearest neighbors of each point.
+    Calculate statistics of the distances to the k-nearest neighbors of points.
 
-    For each point specified in *coordinates*, calculate the median of the
-    Cartesian distance to its *k_nearest* neighbors among the other points in
-    the dataset.
+    For each point specified in *coordinates*, calculate the given statistic on
+    the Cartesian distance to its *k_nearest* neighbors among the other points
+    in the dataset.
+
+    Useful for finding mean/median distances between points, general point
+    spread (standard deviation), variability of neighboring distances
+    (peak-to-peak), etc.
 
     Parameters
     ----------
@@ -29,6 +33,11 @@ def neighbor_distance_statistics(coordinates, *, k_nearest=1, statistic="mean"):
         order compatible with the order of boundaries in *region*. Arrays can
         be Python lists. Arrays can be of any shape but must all have the same
         shape.
+    statistic : str
+        Which statistic to calculate for the distances of the k-nearest
+        neighbors of each point. Valid values are: ``"mean"``,  ``"median"``,
+        ``"std"`` (standard deviation),  ``"var"`` (variance),  ``"ptp"``
+        (peak-to-peak amplitude).
     k_nearest : int
         Will calculate the median of the *k* nearest neighbors of each point. A
         value of 1 will result in the distance to nearest neighbor of each data
@@ -36,49 +45,83 @@ def neighbor_distance_statistics(coordinates, *, k_nearest=1, statistic="mean"):
 
     Returns
     -------
-    distances : array
-        An array with the median distances to the *k* nearest neighbors of each
-        data point. The array will have the same shape as the input coordinate
+    statistics : array
+        An array with the statistic of the k-nearest neighbor distances of each
+        point. The array will have the same shape as the input coordinate
         arrays.
 
     Notes
     -----
     To get the average point spacing for sparse uniformly spaced datasets,
-    using *k_nearest* of 1 is reasonable. Datasets with points clustered into
-    tight groups (e.g., densely sampled along a flight line or ship track) will
-    have very small distances to the closest neighbors, which is not
-    representative of the actual median spacing of points because it doesn't
-    take the spacing between lines into account. In these cases, a median of
-    the 10-20 or more nearest neighbors might be more representative.
+    calculating the mean/median using *k_nearest* of 1 is reasonable. Datasets
+    with points clustered into tight groups (e.g., densely sampled along
+    a flight line or ship track) will have very small distances to the closest
+    neighbors, which is not representative of the actual median spacing of
+    points because it doesn't take the spacing between lines into account. In
+    these cases, a median of the 10-20 or more nearest neighbors might be more
+    representative.
 
     Examples
     --------
+    Generate a grid of points for an example:
+
     >>> import bordado as bd
-    >>> import numpy as np
-    >>> coords = bd.grid_coordinates((5, 10, -20, -17), spacing=1)
-    >>> # The nearest neighbor distance should be the grid spacing
-    >>> distance = median_distance(coords, k_nearest=1)
-    >>> np.allclose(distance, 1)
-    True
-    >>> # The distance has the same shape as the coordinate arrays
-    >>> print(distance.shape, coords[0].shape)
+    >>> coordinates = bd.grid_coordinates((5, 10, -20, -17), spacing=1)
+    >>> print(coordinates[0])
+    [[ 5.  6.  7.  8.  9. 10.]
+     [ 5.  6.  7.  8.  9. 10.]
+     [ 5.  6.  7.  8.  9. 10.]
+     [ 5.  6.  7.  8.  9. 10.]]
+    >>> print(coordinates[1])
+    [[-20. -20. -20. -20. -20. -20.]
+     [-19. -19. -19. -19. -19. -19.]
+     [-18. -18. -18. -18. -18. -18.]
+     [-17. -17. -17. -17. -17. -17.]]
+
+    The mean of the distance to 1 nearest neighbor should be the grid spacing:
+
+    >>> mean_distances = neighbor_distance_statistics(coordinates, "mean", k_nearest=1)
+    >>> print(mean_distances)
+    [[1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]]
+
+    The statistics returned have the same shape as the input coordinates:
+
+    >>> print(mean_distances.shape, coordinates[0].shape)
     (4, 6) (4, 6)
-    >>> # The 2 nearest points should also all be at a distance of 1
-    >>> distance = median_distance(coords, k_nearest=2)
-    >>> np.allclose(distance, 1)
-    True
-    >>> # The 3 nearest points are at a distance of 1 but on the corners they
-    >>> # are [1, 1, sqrt(2)] away. The median for these points is also 1.
-    >>> distance = median_distance(coords, k_nearest=3)
-    >>> np.allclose(distance, 1)
-    True
-    >>> # The 4 nearest points are at a distance of 1 but on the corners they
-    >>> # are [1, 1, sqrt(2), 2] away.
-    >>> distance = median_distance(coords, k_nearest=4)
-    >>> print("{:.2f}".format(np.median([1, 1, np.sqrt(2), 2])))
-    1.21
-    >>> for line in distance:
-    ...     print(" ".join(["{:.2f}".format(i) for i in line]))
+
+    The mean distance to the 2 nearest points should also all be 1 since they
+    are the neighbors along the rows and columns of the matrix:
+
+    >>> mean_distances = neighbor_distance_statistics(coordinates, "mean", k_nearest=2)
+    >>> print(mean_distances)
+    [[1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]]
+
+    The distance to the 3 nearest points is 1 but on the corners of the grid,
+    the distances are [1, 1, sqrt(2)] which leads to a median of 1:
+
+    >>> median_distances = neighbor_distance_statistics(
+    ...     coordinates, "median", k_nearest=3,
+    ... )
+    >>> print(median_distances)
+    [[1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]]
+
+    But using the 4 nearest points leads to distances [1, 1, sqrt(2), 2] at the
+    corners, which results in a median of 1.21.
+
+    >>> median_distances = neighbor_distance_statistics(
+    ...     coordinates, "median", k_nearest=4,
+    ... )
+    >>> for line in median_distances:
+    ...     print(" ".join([f"{i:.2f}" for i in line]))
     1.21 1.00 1.00 1.00 1.00 1.21
     1.00 1.00 1.00 1.00 1.00 1.00
     1.00 1.00 1.00 1.00 1.00 1.00
@@ -89,6 +132,18 @@ def neighbor_distance_statistics(coordinates, *, k_nearest=1, statistic="mean"):
     if k_nearest < 1:
         message = f"Invalid number of neighbors 'k_nearest={k_nearest}'. Must be >= 1."
         raise ValueError(message)
+    statistics = {
+        "mean": np.mean,
+        "median": np.median,
+        "std": np.std,
+        "var": np.var,
+        "ptp": np.ptp,
+    }
+    if statistic not in statistics:
+        message = (
+            f"Invalid statistic '{statistic}'. Must be one of: {statistics.keys()}."
+        )
+        raise ValueError(message)
     shape = np.broadcast(*coordinates).shape
     transposed_coordinates = np.transpose([c.ravel() for c in coordinates])
     tree = scipy.spatial.KDTree(transposed_coordinates)
@@ -98,5 +153,5 @@ def neighbor_distance_statistics(coordinates, *, k_nearest=1, statistic="mean"):
     # the first element returned (the distance) and ignore the rest (the
     # neighbor indices).
     k_distances = tree.query(transposed_coordinates, k=k_nearest + 1)[0][:, 1:]
-    distances = np.median(k_distances, axis=1)
-    return distances.reshape(shape)
+    result = statistics[statistic](k_distances, axis=1)
+    return result.reshape(shape)

--- a/src/bordado/_distance.py
+++ b/src/bordado/_distance.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Functions to calculate the distances between neighbors.
+"""
+
+import numpy as np
+import scipy.spatial
+
+from ._validation import check_coordinates
+
+
+def neighbor_distance_statistics(coordinates, *, k_nearest=1, statistic="mean"):
+    """
+    Median distance between the *k* nearest neighbors of each point.
+
+    For each point specified in *coordinates*, calculate the median of the
+    Cartesian distance to its *k_nearest* neighbors among the other points in
+    the dataset.
+
+    Parameters
+    ----------
+    coordinates : tuple = (easting, northing, ...)
+        Tuple of arrays with the coordinates of each point. Should be in an
+        order compatible with the order of boundaries in *region*. Arrays can
+        be Python lists. Arrays can be of any shape but must all have the same
+        shape.
+    k_nearest : int
+        Will calculate the median of the *k* nearest neighbors of each point. A
+        value of 1 will result in the distance to nearest neighbor of each data
+        point. Must be >= 1. Default is 1.
+
+    Returns
+    -------
+    distances : array
+        An array with the median distances to the *k* nearest neighbors of each
+        data point. The array will have the same shape as the input coordinate
+        arrays.
+
+    Notes
+    -----
+    To get the average point spacing for sparse uniformly spaced datasets,
+    using *k_nearest* of 1 is reasonable. Datasets with points clustered into
+    tight groups (e.g., densely sampled along a flight line or ship track) will
+    have very small distances to the closest neighbors, which is not
+    representative of the actual median spacing of points because it doesn't
+    take the spacing between lines into account. In these cases, a median of
+    the 10-20 or more nearest neighbors might be more representative.
+
+    Examples
+    --------
+    >>> import bordado as bd
+    >>> import numpy as np
+    >>> coords = bd.grid_coordinates((5, 10, -20, -17), spacing=1)
+    >>> # The nearest neighbor distance should be the grid spacing
+    >>> distance = median_distance(coords, k_nearest=1)
+    >>> np.allclose(distance, 1)
+    True
+    >>> # The distance has the same shape as the coordinate arrays
+    >>> print(distance.shape, coords[0].shape)
+    (4, 6) (4, 6)
+    >>> # The 2 nearest points should also all be at a distance of 1
+    >>> distance = median_distance(coords, k_nearest=2)
+    >>> np.allclose(distance, 1)
+    True
+    >>> # The 3 nearest points are at a distance of 1 but on the corners they
+    >>> # are [1, 1, sqrt(2)] away. The median for these points is also 1.
+    >>> distance = median_distance(coords, k_nearest=3)
+    >>> np.allclose(distance, 1)
+    True
+    >>> # The 4 nearest points are at a distance of 1 but on the corners they
+    >>> # are [1, 1, sqrt(2), 2] away.
+    >>> distance = median_distance(coords, k_nearest=4)
+    >>> print("{:.2f}".format(np.median([1, 1, np.sqrt(2), 2])))
+    1.21
+    >>> for line in distance:
+    ...     print(" ".join(["{:.2f}".format(i) for i in line]))
+    1.21 1.00 1.00 1.00 1.00 1.21
+    1.00 1.00 1.00 1.00 1.00 1.00
+    1.00 1.00 1.00 1.00 1.00 1.00
+    1.21 1.00 1.00 1.00 1.00 1.21
+
+    """
+    coordinates = check_coordinates(coordinates)
+    if k_nearest < 1:
+        message = f"Invalid number of neighbors 'k_nearest={k_nearest}'. Must be >= 1."
+        raise ValueError(message)
+    shape = np.broadcast(*coordinates).shape
+    transposed_coordinates = np.transpose([c.ravel() for c in coordinates])
+    tree = scipy.spatial.KDTree(transposed_coordinates)
+    # The k=1 nearest point is going to be the point itself (with a distance of
+    # zero) because we don't remove each point from the dataset in turn. We
+    # don't care about that distance so start with the second closest. Only get
+    # the first element returned (the distance) and ignore the rest (the
+    # neighbor indices).
+    k_distances = tree.query(transposed_coordinates, k=k_nearest + 1)[0][:, 1:]
+    distances = np.median(k_distances, axis=1)
+    return distances.reshape(shape)

--- a/src/bordado/_split.py
+++ b/src/bordado/_split.py
@@ -33,8 +33,9 @@ def block_split(
     Parameters
     ----------
     coordinates : tuple = (easting, northing, ...)
-        Tuple of arrays with the coordinates of each point. The arrays can be
-        n-dimensional.
+        Tuple of arrays with the coordinates of each point. Arrays can be
+        Python lists or any numpy-compatible array type. Arrays can be of any
+        shape but must all have the same shape.
     region : tuple = (W, E, S, N, ...)
         The boundaries of a given region in Cartesian or geographic
         coordinates. If region is not given, will use the bounding region of
@@ -270,8 +271,9 @@ def rolling_window(coordinates, window_size, overlap, *, region=None, adjust="ov
     Parameters
     ----------
     coordinates : tuple = (easting, northing, ...)
-        Tuple of arrays with the coordinates of each point. The arrays can be
-        n-dimensional.
+        Tuple of arrays with the coordinates of each point. Arrays can be
+        Python lists or any numpy-compatible array type. Arrays can be of any
+        shape but must all have the same shape.
     window_size : float
         The size of the windows. Units should match the units of *coordinates*.
         In case the window size is not a multiple of the region, either of them
@@ -498,8 +500,9 @@ def expanding_window(coordinates, center, sizes):
     Parameters
     ----------
     coordinates : tuple = (easting, northing, ...)
-        Tuple of arrays with the coordinates of each point. The arrays can be
-        n-dimensional.
+        Tuple of arrays with the coordinates of each point. Arrays can be
+        Python lists or any numpy-compatible array type. Arrays can be of any
+        shape but must all have the same shape.
     center : tuple = (easting, northing, ...)
         The coordinates of the center of the window. Must have the same number
         of elements as *coordinates*. Coordinates **cannot be arrays**.

--- a/src/bordado/_validation.py
+++ b/src/bordado/_validation.py
@@ -19,7 +19,8 @@ def check_coordinates(coordinates):
     ----------
     coordinates : tuple = (easting, northing, ...)
         Tuple of arrays with the coordinates of each point. Arrays can be
-        Python lists.
+        Python lists or any numpy-compatible array type. Arrays can be of any
+        shape but must all have the same shape.
 
     Returns
     -------

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 The Bordado Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Test distance calculation functions for nearest neighbors.
+"""
+
+import numpy as np
+import numpy.testing as npt
+
+from bordado._distance import median_distance
+from bordado._grid import grid_coordinates
+
+
+def test_distance_nearest():
+    "On a regular grid, distances should be straight forward for 1st neighbor"
+    spacing = 0.5
+    coords = grid_coordinates((5, 10, -20, -17), spacing=spacing)
+
+    distance = median_distance(coords, k_nearest=1)
+    # The nearest neighbor distance should be the grid spacing
+    npt.assert_allclose(distance, spacing)
+    assert distance.shape == coords[0].shape
+
+    # The shape should be the same even if we ravel the coordinates
+    coords = tuple(coord.ravel() for coord in coords)
+    distance = median_distance(coords, k_nearest=1)
+    # The nearest neighbor distance should be the grid spacing
+    npt.assert_allclose(distance, spacing)
+    assert distance.shape == coords[0].shape
+
+
+def test_distance_k_nearest():
+    "Check the median results for k nearest neighbors"
+    coords = grid_coordinates((5, 10, -20, -17), spacing=1)
+
+    # The 2 nearest points should also all be at a distance of 1 spacing
+    distance = median_distance(coords, k_nearest=2)
+    npt.assert_allclose(distance, 1)
+
+    # The 3 nearest points are at a distance of 1 but on the corners they are
+    # [1, 1, sqrt(2)] away. The median for these points is also 1.
+    distance = median_distance(coords, k_nearest=3)
+    npt.assert_allclose(distance, np.median([1, 1, np.sqrt(2)]))
+
+    # The 4 nearest points are at a distance of 1 but on the corners they are
+    # [1, 1, sqrt(2), 2] away.
+    distance = median_distance(coords, k_nearest=4)
+    true = np.ones_like(coords[0])
+    corners = np.median([1, 1, np.sqrt(2), 2])
+    true[0, 0] = true[0, -1] = true[-1, 0] = true[-1, -1] = corners
+    npt.assert_allclose(distance, true)


### PR DESCRIPTION
The function can calculate mean, median, standard deviation, variance, and peak-to-peak amplitude of the distances between each points k-nearest neighbors. This is useful for evaluating the spread of points. This function was originally `verde.median_distance` and generalized and expanded when ported here.

**Relevant issues/PRs:** #27 
