### PR TITLE
Remove validation functions from the public API

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -46,13 +46,3 @@ Other utilities
    neighbor_distance_statistics
    spacing_to_size
    shape_to_spacing
-
-Validation of inputs
---------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   check_coordinates
-   check_region
-   check_shape

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -15,7 +15,6 @@ from ._random import random_coordinates
 from ._region import get_region, inside, pad_region
 from ._split import block_split, expanding_window, rolling_window
 from ._utils import shape_to_spacing, spacing_to_size
-from ._validation import check_coordinates, check_region, check_shape
 from ._version import __version__
 
 # Append a leading "v" to the generated version by setuptools_scm


### PR DESCRIPTION
The `check_*` functions are used widely internally and we have put them on the API in case others want to use them. But their specs can change with time and maintaining compatibility would be a pain. Different projects can also have different requirements of the inputs so these are hard to generalize. Keep them private instead to avoid issues in the future.

**Relevant issues/PRs:** Fixes #45 
