### PR TITLE
Add a function to generate random points on a sphere

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -15,6 +15,7 @@ Coordinate generation
 
    line_coordinates
    random_coordinates
+   random_coordinates_spherical
    grid_coordinates
    profile_coordinates
    great_circle_coordinates

--- a/src/bordado/__init__.py
+++ b/src/bordado/__init__.py
@@ -12,7 +12,7 @@ from ._distance import neighbor_distance_statistics
 from ._grid import grid_coordinates
 from ._line import line_coordinates
 from ._profile import great_circle_coordinates, profile_coordinates
-from ._random import random_coordinates
+from ._random import random_coordinates, random_coordinates_spherical
 from ._region import get_region, inside, pad_region
 from ._split import (
     block_split,

--- a/src/bordado/_grid.py
+++ b/src/bordado/_grid.py
@@ -11,6 +11,7 @@ Generate coordinates for regular n-dimensional grids.
 import numpy as np
 
 from ._line import line_coordinates
+from ._utils import make_non_dimensional_coordinates
 from ._validation import check_region, check_shape
 
 
@@ -347,7 +348,9 @@ def grid_coordinates(
     # this means we have to reverse the list going in to get the right shape
     # and reverse it coming out to get the right order of coordinates.
     coordinates = list(reversed(np.meshgrid(*reversed(coordinates_1d), indexing="ij")))
-    if non_dimensional_coords is not None:
-        for value in np.atleast_1d(non_dimensional_coords):
-            coordinates.append(np.full_like(coordinates[0], value))
+    coordinates.extend(
+        make_non_dimensional_coordinates(
+            non_dimensional_coords, coordinates[0].shape, coordinates[0].dtype
+        )
+    )
     return tuple(coordinates)

--- a/src/bordado/_random.py
+++ b/src/bordado/_random.py
@@ -11,7 +11,7 @@ Functions for generating random point spreads.
 import numpy as np
 
 from ._utils import make_non_dimensional_coordinates
-from ._validation import check_region
+from ._validation import check_region, check_region_geographic, longitude_continuity
 
 
 def random_coordinates(region, size, *, random_seed=None, non_dimensional_coords=None):
@@ -108,12 +108,119 @@ def random_coordinates(region, size, *, random_seed=None, non_dimensional_coords
     return tuple(coordinates)
 
 
-def random_coordinates_spherical(region, size, *, random_seed=None, non_dimensional_coords=None):
+def random_coordinates_spherical(
+    region, size, *, random_seed=None, non_dimensional_coords=None
+):
+    """
+    Generate the coordinates for a uniformly random scatter on the sphere.
+
+    Points drawn from a simple uniform distribution of longitude and latitude
+    will tend to be more concentrated towards the poles. This function accounts
+    for that and is able generate a uniformly random distribution on the
+    surface of a sphere.
+
+    Parameters
+    ----------
+    region : tuple = (W, E, S, N)
+        The boundaries of a given region in geographic coordinates. Should have
+        a lower and an upper boundary for each dimension of the coordinate
+        system.
+    size : int
+        The number of points to generate.
+    random_seed : None or int or numpy.random.Generator
+        A seed for a random number generator (RNG) used to generate the
+        coordinates. If an integer is given, it will be used as a seed for
+        :func:`numpy.random.default_rng` which will then be used as the
+        generator. If a :class:`numpy.random.Generator` is given, it will be
+        used. If ``None`` is given, :func:`~numpy.random.default_rng` will be
+        used with no seed to create a generator (resulting in different numbers
+        with each run). Use a seed to make sure computations are reproducible.
+        Default is None.
+    non_dimensional_coords : None, scalar, or tuple of scalars
+        If not None, then value(s) of extra non-dimensional coordinates
+        (coordinates that aren't part of the sample dimensions, like height for
+        a lat/lon grid). Will generate extra coordinate arrays from these
+        values with the same shape of the final coordinates and the constant
+        value given here. Use this to generate arrays of constant heights or
+        times, for example, which might be needed to accompany a set of points.
+
+    Returns
+    -------
+    coordinates : tuple of arrays
+        Arrays with the longitude, latitude, and non-dimensional coordinates,
+        in order, of each point in the grid. Each array contains values for
+        a dimension in an order compatible with *region* followed by any extra
+        dimensions given in *non_dimensional_coords*. All arrays will have the
+        specified *size*.
+
+    Examples
+    --------
+    We can generate the random coordinates on the entire surface of a sphere
+    like so:
+
+    >>> coordinates = random_coordinates_spherical(
+    ...     region=(0, 360, -90, 90), size=10, random_seed=42,
+    ... )
+
+    We set a seed here to make sure our examples always return the same values.
+    If you need different values every time you run your code, then either omit
+    ``random_seed`` or set it to ``None``.
+
+    >>> import numpy as np
+
+    The first coordinate is the longitude:
+
+    >>> print(np.array_str(coordinates[0], precision=1))
+    [278.6 158.  309.1 251.1  33.9 351.2 274.  283.   46.1 162.1]
+
+    And the second is the latitude:
+
+    >>> print(np.array_str(coordinates[1], precision=1))
+    [-15.   58.6  16.7  40.2  -6.5 -33.1   6.3 -60.7  40.9  15.3]
+
+    To show how this differs from :func:`bordado.random_coordinates`, we can
+    generate a large number of points and calculate the point density per
+    latitude band. We expect the concentration to be uniform since we want
+    uniformly distributed numbers.
+
+    First, we'll define a function that calculates the point density per 10
+    degree band of latitude:
+
+    >>> import bordado as bd
+    >>> def point_density(coordinates, region):
+    ...     # Define the latitude bands
+    ...     bands = bd.line_coordinates(*region[2:], spacing=10)
+    ...     # Calculate the area of each band.
+    ...     # See https://en.wikipedia.org/wiki/Spherical_cap
+    ...     areas = 2 * np.pi * abs(
+    ...         np.sin(np.radians(bands[:-1])) - np.sin(np.radians(bands[1:]))
+    ...     )
+    ...     # Figure out how many points are in each band
+    ...     points_per_band = np.array([
+    ...         bd.inside(
+    ...             coordinates,
+    ...             [*region[:2], bands[i], bands[i + 1]],
+    ...         ).sum()
+    ...         for i in range(bands.size - 1)
+    ...     ])
+    ...     # Calculate the density
+    ...     density = points_per_band / areas
+    ...     return density
+
+    Now we can calculate the point density:
+
+    """
+    check_region_geographic(region)
+    region = longitude_continuity(region)
     random = np.random.default_rng(random_seed)
     colat_south = np.radians(90 - region[2])
     colat_north = np.radians(90 - region[3])
     xmin = (1 + np.cos(colat_north)) / 2
     xmax = (1 + np.cos(colat_south)) / 2
+    # This can happen when using -90, 90 for latitudes. It causes an error in
+    # the uniform sampler.
+    if xmin > xmax:
+        xmin, xmax = xmax, xmin
     coordinates = [
         random.uniform(*region[:2], size),
         90 - np.degrees(np.arccos(2 * random.uniform(xmin, xmax, size) - 1)),

--- a/src/bordado/_random.py
+++ b/src/bordado/_random.py
@@ -10,6 +10,7 @@ Functions for generating random point spreads.
 
 import numpy as np
 
+from ._utils import make_non_dimensional_coordinates
 from ._validation import check_region
 
 
@@ -99,7 +100,27 @@ def random_coordinates(region, size, *, random_seed=None, non_dimensional_coords
     coordinates = []
     for lower, upper in np.reshape(region, (len(region) // 2, 2)):
         coordinates.append(random.uniform(lower, upper, size))
-    if non_dimensional_coords is not None:
-        for value in np.atleast_1d(non_dimensional_coords):
-            coordinates.append(np.full_like(coordinates[0], value))
+    coordinates.extend(
+        make_non_dimensional_coordinates(
+            non_dimensional_coords, coordinates[0].shape, coordinates[0].dtype
+        )
+    )
+    return tuple(coordinates)
+
+
+def random_coordinates_spherical(region, size, *, random_seed=None, non_dimensional_coords=None):
+    random = np.random.default_rng(random_seed)
+    colat_south = np.radians(90 - region[2])
+    colat_north = np.radians(90 - region[3])
+    xmin = (1 + np.cos(colat_north)) / 2
+    xmax = (1 + np.cos(colat_south)) / 2
+    coordinates = [
+        random.uniform(*region[:2], size),
+        90 - np.degrees(np.arccos(2 * random.uniform(xmin, xmax, size) - 1)),
+    ]
+    coordinates.extend(
+        make_non_dimensional_coordinates(
+            non_dimensional_coords, coordinates[0].shape, coordinates[0].dtype
+        )
+    )
     return tuple(coordinates)

--- a/src/bordado/_utils.py
+++ b/src/bordado/_utils.py
@@ -8,6 +8,8 @@
 Functions for validating and manipulation coordinate arrays.
 """
 
+import numpy as np
+
 from ._validation import check_adjust, check_region, check_shape
 
 
@@ -171,3 +173,62 @@ def shape_to_spacing(region, shape, *, pixel_register=False):
             n_points -= 1
         spacing.append((region[2 * i + 1] - region[2 * i]) / n_points)
     return tuple(reversed(spacing))
+
+
+def make_non_dimensional_coordinates(values, shape, dtype):
+    """
+    Make a list of arrays with the given values of non-dimensional coordinates.
+
+    These are coordinates that are not part of the dimensions of a grid or
+    spread of points. Think of them as extra coordinates.
+
+    Parameters
+    ----------
+    values : None or float or list or array
+        The values of the non-dimensional coordinates. If None, an empty list
+        will be returned. If a float, will generate one array of the desired
+        shape with this value as the fill. If a list or array, will generate
+        one array of the given shape per value in the list or array.
+    shape : tuple
+        The shape of the desired array(s).
+    dtype : str
+        A numpy compatible dtype used for the output array.
+
+    Returns
+    -------
+    coordinates : list
+        List of arrays generated. Even if a single value is passed, the output
+        will still be a list with a single array.
+
+    Examples
+    --------
+    Generating a single array:
+
+    >>> make_non_dimensional_coordinates(10, (2,), dtype="int")
+    [array([10, 10])]
+    >>> make_non_dimensional_coordinates(10, (2, 2), dtype="int")
+    [array([[10, 10],
+           [10, 10]])]
+
+    To generate multiple arrays:
+
+    >>> make_non_dimensional_coordinates([10, 20], (2,), dtype="int")
+    [array([10, 10]), array([20, 20])]
+    >>> import numpy as np
+    >>> make_non_dimensional_coordinates(np.array([10, 20]), (2,), dtype="int")
+    [array([10, 10]), array([20, 20])]
+    >>> make_non_dimensional_coordinates(
+    ...     np.array([[10], [20]]), (2,), dtype="int",
+    ... )
+    [array([10, 10]), array([20, 20])]
+
+    If None is given:
+
+    >>> make_non_dimensional_coordinates(None, (2,), dtype="int")
+    []
+    """
+    coordinates = []
+    if values is not None:
+        for value in np.atleast_1d(values).ravel():
+            coordinates.append(np.full(shape, value, dtype=dtype))
+    return coordinates


### PR DESCRIPTION
Generates uniform randomly distributed points on the surface of a sphere. Using the regular `random_coordinates` for this would lead to denser sampling at higher latitudes. To achieve this, we sample the cosine of latitude (in this case, colatitude) instead of the angles themselves. Test the code by calculating the point density per latitude band and making sure it's roughly uniform.