### PR TITLE
Fix broken clean target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,8 @@ check-actions:
 	zizmor $(GITHUB_ACTIONS)
 
 clean:
-	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*.orig" -exec rm -v {} \;
 	find . -name ".coverage.*" -exec rm -v {} \;
-	find . -name "__pycache__" -exec rm -v {} \;
-	find . -name "*.egg-info " -exec rm -v {} \;
+	find . -depth -name "__pycache__" -exec rm -rfv {} \;
+	find . -depth -name "*.egg-info" -exec rm -rfv {} \;
 	rm -rvf build dist MANIFEST .coverage .cache .pytest_cache src/$(PROJECT)/_version.py


### PR DESCRIPTION
The `find` commands failed to delete some temporary folders because `find` and `rm` work in opposite directions (child to parent vs parent to child). This lead to `find` exiting with an error about missing folders and the rest of the commands not running. Fix by passing `-depth` to `find` to reverse its operations.