### PR TITLE
Gather pages from tutorial and how to in the docs table of contents

### DIFF
--- a/doc/how-to/index.rst
+++ b/doc/how-to/index.rst
@@ -1,0 +1,23 @@
+.. _how-to:
+
+How To
+======
+
+These are more self-contained examples of how to use Bordado to solve certain
+problems. They are meant for more experienced users who want to explore
+different use cases or solve a specific problem.
+
+If you're **new to Bordado** and are looking for a guided tour, we recommend
+the ":ref:`tutorial`" first.
+
+.. toctree::
+    :maxdepth: 1
+    :numbered:
+    :caption: Contents
+
+    get-region.rst
+
+.. seealso::
+
+    Want to know the details of how each function works? That is all in the
+    ":ref:`api`".

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -166,20 +166,10 @@ file.
 .. toctree::
     :hidden:
     :maxdepth: 1
-    :caption: Tutorial
+    :caption: User Guide
 
-    tutorial/line.rst
-    tutorial/grid.rst
-    tutorial/profile.rst
-    tutorial/random.rst
-    tutorial/split.rst
-
-.. toctree::
-    :hidden:
-    :maxdepth: 1
-    :caption: How To
-
-    how-to/get-region.rst
+    tutorial/index.rst
+    how-to/index.rst
 
 .. toctree::
     :maxdepth: 1

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -95,10 +95,10 @@ which generates the values and uses :func:`numpy.meshgrid` appropriately:
 Explore the rest!
 -----------------
 
-That's a brief overview of the functionality in Bordado but there's plenty
-more! We recommend going through our tutorial first, starting at
-":ref:`tutorial_line`".
-Then take a look at the ":ref:`api`" and the documentation for each function.
+That's a brief overview of the functionality in Bordado, but there's plenty
+more! We recommend going through our :ref:`tutorial` first.
+Then take a look at the ":ref:`how-to`" and also the ":ref:`api`" for
+documentation for each function.
 
 Oh, and don't forget to :ref:`cite Bordado <citing>` if you use it in
 a publication!

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -1,0 +1,24 @@
+.. _tutorial:
+
+Tutorial
+========
+
+The tutorial introduces Bordado and goes over the ways in which it can be used,
+including how some parameters work and example applications. **If you're new to
+the project**, this is the perfect place to start.
+
+.. toctree::
+    :maxdepth: 1
+    :numbered:
+    :caption: Contents
+
+    line.rst
+    grid.rst
+    profile.rst
+    random.rst
+    split.rst
+
+.. seealso::
+
+    Looking for something more direct? Check out ":ref:`how-to`" for
+    self-contained examples of solving problems with Bordado.


### PR DESCRIPTION
The Tutorial and How To sections had pages all at level 1 of the main table of contents. This made the sidebar long since every subpage was listed there as a top-level page. Create index pages for both sections and only include those in the main table of contents. Then gather the Tutorial and How To indices into a "User Guide" category in the main table of contents. This makes the side-bar smaller and easier to navigate, plus it gives good linking points to the tutorial and how to sections (which we didn't have before).

**Relevant issues/PRs:** Improves what was done in #80 and #92.