### PR TITLE
Fetch Ensaio data from GitHub when building the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -111,6 +111,8 @@ jobs:
 
       - name: Build the documentation
         run: make -C doc clean all
+        env:
+          ENSAIO_DATA_DIR: ${{ runner.temp }}/cache/ensaio
 
       # Store the docs as a build artifact so we can deploy it later
       - name: Upload HTML documentation as an artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -103,6 +103,12 @@ jobs:
       - name: Install the package
         run: python -m pip install --no-deps dist/*.whl
 
+      - name: Cache the Ensaio datasets
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/cache/ensaio
+          key: ensaio-data
+
       - name: Build the documentation
         run: make -C doc clean all
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -38,7 +38,8 @@ html: api
 	@echo "Building HTML files."
 	@echo
 	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
-	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	# Tell Ensaio to download from GitHub to avoid spamming data repositories on CI
+	ENSAIO_DATA_FROM_GITHUB="true" PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
Set the appropriate environment variable in the `doc/Makefile` to tell Ensaio to download data from GitHub and not Zenodo. This is to avoid spamming Zenodo on CI, where the data cache is not always maintained. Setup caching of the datasets on CI to avoid downloading them too much on long PRs.
