### PR TITLE
Fix rolling_window check of window_size for higher dimensions

### DIFF
--- a/src/bordado/_split.py
+++ b/src/bordado/_split.py
@@ -452,7 +452,11 @@ def rolling_window(coordinates, window_size, overlap, *, region=None, adjust="ov
     else:
         check_region(region)
     # Check if window size is bigger than the minimum dimension of the region
-    if window_size > min(region[1] - region[0], region[3] - region[2]):
+    # across all dimensions (region pairs), not just the first two.
+    region_dimensions = [
+        region[2 * i + 1] - region[2 * i] for i in range(len(region) // 2)
+    ]
+    if window_size > min(region_dimensions):
         message = (
             f"Invalid window size '{window_size}'. Cannot be larger than dimensions of "
             f"the region '{region}'."

--- a/test/test_split.py
+++ b/test/test_split.py
@@ -25,6 +25,19 @@ def test_rolling_window_size_too_large():
         rolling_window(coordinates, window_size=1.1, overlap=0.5)
 
 
+def test_rolling_window_size_too_large_higher_dim():
+    "Window size check should apply to all region dimensions, not just the first two."
+    import numpy as np
+
+    coordinates = (
+        np.array([-2.0, 0.0, 2.0]),
+        np.array([-2.0, 0.0, 2.0]),
+        np.array([-0.5, 0.0, 0.5]),
+    )
+    with pytest.raises(ValueError, match="Invalid window size"):
+        rolling_window(coordinates, window_size=2, overlap=0.5)
+
+
 def test_rolling_window_spherical_invalid_window_size():
     "Make sure an exception is raised if the window size is less than 0."
     region = (0, 1, 2, 4)

--- a/test/test_split.py
+++ b/test/test_split.py
@@ -11,6 +11,7 @@ A large number of the unit tests are done as doctests in the function
 docstrings.
 """
 
+import numpy as np
 import pytest
 
 from bordado._grid import grid_coordinates
@@ -27,8 +28,6 @@ def test_rolling_window_size_too_large():
 
 def test_rolling_window_size_too_large_higher_dim():
     "Window size check should apply to all region dimensions, not just the first two."
-    import numpy as np
-
     coordinates = (
         np.array([-2.0, 0.0, 2.0]),
         np.array([-2.0, 0.0, 2.0]),


### PR DESCRIPTION
Fixes #79.

The window_size > region check in `rolling_window` only compared against the first two region pairs (`region[1] - region[0]` and `region[3] - region[2]`), so for 3D+ coordinates the check was effectively skipped. A window_size larger than the third (or higher) dimension would then fail later inside `pad_region` with a cryptic `Lower boundary larger than upper boundary` ValueError.

Now iterates over every `(lower, upper)` pair in the region tuple and checks against the minimum dimension across all of them, restoring the intended error message and behavior for n-dimensional coordinates.

Added a regression test in `test/test_split.py` covering the 3D case from the bug report.