### PR TITLE
Fix missing write permission in publish Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - docs-deploy-permission
   release:
     types:
       - published
@@ -23,10 +24,12 @@ defaults:
     shell: bash -e -l {0}
 
 jobs:
-  #############################################################################
-  # Build the docs
-  build:
+
+  deploy:
     runs-on: ubuntu-latest
+    # Grant write permissions so that we can push to gh-pages
+    permissions:
+      contents: write
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
       PYTHON: "3.14"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,12 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    # Grant write permissions so that we can push to gh-pages
     permissions:
+      # Grant write permissions so that we can push to gh-pages
       contents: write
+      # This permission allows trusted publishing to PyPI (without an API token)
+      id-token: write
+    environment: pypi
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
       PYTHON: "3.14"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - docs-deploy-permission
   release:
     types:
       - published


### PR DESCRIPTION
The docs couldn't be pushed to the `gh-pages` branch because the job lacked the "write" permission. Also add permission and environment for PyPI/TestPyPI trusted publishing.

Fixes issues from #115 

