### PR TITLE
Revise Actions workflows to only run when necessary

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,21 @@
 # Build the documentation to test that it works without errors
 #
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
 name: docs
 
-# Only build PRs and pushes to the main branch.
+# Don't build on pushes to main because publish.yml will already do it.
 on:
   pull_request:
-  push:
-    branches:
-      - main
+    paths:
+      - doc
+      - src
+      - pyproject.toml
+      - env/requirements-build.txt
+      - env/requirements-docs.txt
+      - .github/workflows/docs.yml
 
 permissions: {}
 
@@ -18,11 +26,9 @@ defaults:
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
     # -e makes sure builds fail if any command fails
-    shell: bash -e -l {0}
+    shell: bash -e -o pipefail -l {0}
 
 jobs:
-  #############################################################################
-  # Build the docs
   build:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 # Build and publish packages to PyPI and documentation to GitHub Pages
 #
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
 name: publish
 
 # Only pushed to the main branch and releases.
@@ -20,10 +24,9 @@ defaults:
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
     # -e makes sure builds fail if any command fails
-    shell: bash -e -l {0}
+    shell: bash -e -o pipefail -l {0}
 
 jobs:
-
   deploy:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,4 +1,4 @@
-# Linting and style checks with GitHub Actions
+# Linting and style checks
 #
 # NOTE: Pin actions to a specific commit to avoid having the authentication
 # token stolen if the Action is compromised. See the comments and links here:
@@ -6,10 +6,16 @@
 #
 name: code-style
 
-# Only build PRs and the main branch. Pushes to branches will only be built
-# when a PR is opened.
+# Only run on main or when relevant sources where edited.
 on:
   pull_request:
+    paths:
+      - src
+      - test
+      - doc/conf.py
+      - pyproject.toml
+      - env/requirements-style.txt
+      - .github/workflows/style.yml
   push:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,21 @@
 # Configuration for running tests with GitHub Actions
 #
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
 name: test
 
-# Only build PRs, the main branch, and releases. Pushes to branches will only
-# be built when a PR is opened. This avoids duplicated buids in PRs comming
-# from branches in the origin repository (1 for PR and 1 for push).
+# Only run on main or when relevant sources where edited.
 on:
   pull_request:
+    paths:
+      - src
+      - test
+      - pyproject.toml
+      - env/requirements-build.txt
+      - env/requirements-test.txt
+      - .github/workflows/test.yml
   push:
     branches:
       - main


### PR DESCRIPTION
Make the workflows a bit leaner and more standard. Only trigger running them when relevant files are changed in PRs.