### PR TITLE
Pin code linters and formatters and use Dependabot for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
 
@@ -10,3 +5,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+    allow:
+      - dependency-name: "zizmor"
+        update-types: "version-update:semver-minor"
+      - dependency-name: "ruff"
+        update-types: "version-update:semver-minor"
+      - dependency-name: "burocrata"
+        update-types: "version-update:semver-minor"

--- a/env/requirements-style.txt
+++ b/env/requirements-style.txt
@@ -1,3 +1,3 @@
-ruff
-burocrata
-zizmor
+ruff==0.15.*
+burocrata==0.3.*
+zizmor==1.25.*


### PR DESCRIPTION
Pinning them means that they checks won't randomly break on unrelated PRs. Having Dependabot open PRs to update them will let us test the updates in isolation. Leave them unpinned in the conda environment because it would have to be refreshed manually in each person's computer anyway when updates are merged.