### PR TITLE
Fix wrong syntax in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,11 @@ updates:
       - dependency-name: "*"
     allow:
       - dependency-name: "zizmor"
-        update-types: "version-update:semver-minor"
+        update-types:
+          - "version-update:semver-minor"
       - dependency-name: "ruff"
-        update-types: "version-update:semver-minor"
+        update-types:
+          - "version-update:semver-minor"
       - dependency-name: "burocrata"
-        update-types: "version-update:semver-minor"
+        update-types:
+          - "version-update:semver-minor"


### PR DESCRIPTION
Seems like the `update-types` option needs to be a list. But since dependabot doesn't run on PRs it's hard to check before merging.

