### PR TITLE
Tell Dependabot to only look at the `env` folder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "env/"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
Otherwise, it'll try to scan our pyproject.toml and we don't want that right now.