### PR TITLE
Try not ignoring all in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     directory: "env/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
     allow:
       - dependency-name: "zizmor"
         update-types:


### PR DESCRIPTION
The config was ignoring all and then allowing only specific packages. But this doesn't work since all are ignored. Try using only the `allow` config.


