### PR TITLE
Fix paths for GitHub Actions triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ name: docs
 on:
   pull_request:
     paths:
-      - doc
-      - src
+      - doc/**
+      - src/**
       - pyproject.toml
       - env/requirements-build.txt
       - env/requirements-docs.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,8 +10,8 @@ name: code-style
 on:
   pull_request:
     paths:
-      - src
-      - test
+      - src/**
+      - test/**
       - doc/conf.py
       - pyproject.toml
       - env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ name: test
 on:
   pull_request:
     paths:
-      - src
-      - test
+      - src/**
+      - test/**
       - pyproject.toml
       - env/requirements-build.txt
       - env/requirements-test.txt


### PR DESCRIPTION
The triggers didn't include the `/**` when specifying folders so the workflows weren't being triggered properly.

**Relevant issues/PRs:** Ported here from #108 