### PR TITLE
Make arguments to rotate_coordinates and check_adjust keyword-only

### DIFF
--- a/src/bordado/_transform.py
+++ b/src/bordado/_transform.py
@@ -117,7 +117,7 @@ def rescale_coordinates(coordinates, region):
     return tuple(rescaled_coordinates)
 
 
-def rotate_coordinates(coordinates, angle, rotation_center=(0, 0)):
+def rotate_coordinates(coordinates, angle, *, rotation_center=(0, 0)):
     r"""
     Rotate coordinates in 2-dimensional space.
 

--- a/src/bordado/_validation.py
+++ b/src/bordado/_validation.py
@@ -174,7 +174,7 @@ def check_region_geographic(region):
         raise ValueError(message)
 
 
-def check_adjust(adjust, valid=("spacing", "region")):
+def check_adjust(adjust, *, valid=("spacing", "region")):
     """
     Check if the adjust argument is valid.
 


### PR DESCRIPTION
These arguments should have been keyword-only from the start but they were forgotten. Having keyword only arguments makes it harder to have bugs and errors from passing values to the wrong function arguments.

Fixes what should have been done in #128 